### PR TITLE
docs: launch GitHub Pages docs and align logging guidance

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,33 @@
+name: Docs
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install MkDocs
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs mkdocs-material
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ SQLPack provides a unified command-line interface for database operations:
 
 The tool combines PowerShell and Bash scripts for maximum cross-platform compatibility.
 
+## Documentation
+
+- Online Docs (GitHub Pages): https://lionsad.github.io/sqlpack/
+- Local preview: `pip install mkdocs mkdocs-material && mkdocs serve`
+- First-time setup for GitHub Pages: merge to main, then in GitHub → Settings → Pages set Source to "Deploy from a branch" with Branch `gh-pages` and Folder `/ (root)`.
+
 ## Quick Start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ SQLPack provides a unified command-line interface for database operations:
 - **sqlpack import**: Import database from archive into local environments
 - **sqlpack export-data**: Advanced data export using BCP with native format files
 - **sqlpack doctor**: Validate required tools and environment
-- **sqlpack install**: Print or execute dependency install commands (macOS/Debian)
+- **sqlpack install-tools**: Print or execute dependency install commands (macOS/Debian)
 
 The tool combines PowerShell and Bash scripts for maximum cross-platform compatibility.
 
@@ -22,8 +22,8 @@ The tool combines PowerShell and Bash scripts for maximum cross-platform compati
 sudo make install
 
 # Validate your environment
-sqlpack install           # Preview install commands for missing deps
-sqlpack install --execute # Run the commands
+sqlpack install-tools           # Preview install commands for missing deps
+sqlpack install-tools --execute # Run the commands
 sqlpack doctor
 
 # Export a database

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ The tool combines PowerShell and Bash scripts for maximum cross-platform compati
 # Install SQLPack
 sudo make install
 
+# Validate your environment
+sqlpack doctor
+
 # Export a database
 sqlpack export --server localhost,1433 --database MyApp
 
@@ -29,6 +32,14 @@ sqlpack import --archive db-dump.tar.gz --database MyAppDev
 sqlpack help
 sqlpack export --help
 ```
+
+## Prerequisites (Tools)
+
+Ensure these tools are installed and on PATH:
+- sqlcmd and bcp (mssql-tools18). See docs: docs/install.md
+- PowerShell 7+ (`pwsh`)
+- dbatools PowerShell module (see https://docs.dbatools.io/)
+- tar utility (macOS/Linux)
 
 ## Files Created
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ SQLPack provides a unified command-line interface for database operations:
 - **sqlpack export**: Export complete database schema and data
 - **sqlpack import**: Import database from archive into local environments
 - **sqlpack export-data**: Advanced data export using BCP with native format files
+- **sqlpack doctor**: Validate required tools and environment
+- **sqlpack install**: Print or execute dependency install commands (macOS/Debian)
 
 The tool combines PowerShell and Bash scripts for maximum cross-platform compatibility.
 
@@ -20,6 +22,8 @@ The tool combines PowerShell and Bash scripts for maximum cross-platform compati
 sudo make install
 
 # Validate your environment
+sqlpack install           # Preview install commands for missing deps
+sqlpack install --execute # Run the commands
 sqlpack doctor
 
 # Export a database
@@ -128,6 +132,7 @@ DB_ROW_LIMIT=10000 \
 DB_SCHEMA_ONLY_TABLES="AuditLog,TempData" \
 DB_EXPORT_DIR="./exports" \
 DB_ARCHIVE_NAME="myapp-dev-dump.tar.gz" \
+DB_TRUST_SERVER_CERTIFICATE=true \
 sqlpack export --server localhost,1499 --database MyApp --username sa --password MyPassword
 ```
 
@@ -307,6 +312,7 @@ pwsh ./commands/export.ps1 -SqlInstance "server" -Database "db" -Verbose
 | `DB_EXPORT_DIR` | Export directory |
 | `DB_ARCHIVE_NAME` | Archive filename |
 | `DB_ROW_LIMIT` | Maximum rows per table |
+| `DB_TRUST_SERVER_CERTIFICATE` | Trust server certificate (true/false) |
 
 ## Performance Considerations
 
@@ -368,3 +374,10 @@ sqlpack import --archive db-dump.tar.gz --database MyAppDev --force
 ## License
 
 MIT License - see [LICENSE](LICENSE) file for details.
+
+## Development
+
+- Run from source: `./sqlpack help`
+- Lint Bash scripts: `make lint` (uses shellcheck if available)
+- Run tests: `make test` (runs Bats tests in `tests/` if installed)
+- Increase logging during local runs: `BASH_LOG=debug ./sqlpack import ...` or `PS_LOG_LEVEL=trace pwsh ./commands/export.ps1 ...`

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ sqlpack export --help
 
 ## Prerequisites (Tools)
 
+See installation steps in [docs/install.md](docs/install.md).
+
 Ensure these tools are installed and on PATH:
-- sqlcmd and bcp (mssql-tools18). See docs: docs/install.md
+- sqlcmd and bcp (mssql-tools18)
 - PowerShell 7+ (`pwsh`)
 - dbatools PowerShell module (see https://docs.dbatools.io/)
 - tar utility (macOS/Linux)

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ sqlpack export --help
 
 ## Files Created
 
+Default output directory for exports is `./db-export`.
+
 ```
-output/
+db-export/
 ├── schemas.txt             # Ordered list of schema files for import
 ├── schema-tables.sql       # Database tables
 ├── schema-constraints.sql  # Foreign keys and constraints
@@ -45,7 +47,8 @@ output/
 │   ├── dbo.Users.dat       # Native format data files
 │   ├── dbo.Users.fmt       # BCP format files
 │   └── ...
-└── db-dump.tar.gz          # Compressed archive of all files
+
+db-dump.tar.gz              # Compressed archive of files above (created in CWD)
 ```
 
 ## Prerequisites
@@ -229,21 +232,21 @@ Use the `PS_LOG_LEVEL` environment variable or command-line switches:
 
 ```powershell
 # Default - informational level
-.\export.ps1 -SqlInstance "server" -Database "db"
+pwsh ./commands/export.ps1 -SqlInstance "server" -Database "db"
 
 # Verbose output
-.\export.ps1 -SqlInstance "server" -Database "db" -Verbose
+pwsh ./commands/export.ps1 -SqlInstance "server" -Database "db" -Verbose
 
 # Debug output
-.\export.ps1 -SqlInstance "server" -Database "db" -Debug
+pwsh ./commands/export.ps1 -SqlInstance "server" -Database "db" -Debug
 
 # Environment variable approach
 $env:PS_LOG_LEVEL = "Debug"
-.\export.ps1 -SqlInstance "server" -Database "db"
+pwsh ./commands/export.ps1 -SqlInstance "server" -Database "db"
 
 # Add timestamps
 $env:PS_LOG_TIMESTAMP = "true"
-.\export.ps1 -SqlInstance "server" -Database "db" -Verbose
+pwsh ./commands/export.ps1 -SqlInstance "server" -Database "db" -Verbose
 ```
 
 **PowerShell Log Levels:**
@@ -262,10 +265,11 @@ $env:PS_LOG_TIMESTAMP = "true"
 | `-Database` | Yes | Database name to export |
 | `-Username` | No | SQL Server username (uses Windows auth if omitted) |
 | `-Password` | No | SQL Server password |
-| `-OutputPath` | No | Output directory (default: "./output") |
+| `-OutputPath` | No | Output directory (default: "./db-export") |
 | `-TarFileName` | No | Archive filename (default: "db-dump.tar.gz") |
 | `-SchemaOnlyTables` | No | Array of tables to export schema only (no data) |
 | `-DataRowLimit` | No | Maximum rows per table (default: unlimited) |
+| `-TrustServerCertificate` | No | Trust server certificate (bypass SSL validation) |
 
 ### import.sh
 | Parameter | Required | Description |
@@ -277,6 +281,8 @@ $env:PS_LOG_TIMESTAMP = "true"
 | `-p, --password` | No | SQL Server password |
 | `-f, --force` | No | Force recreate database if exists |
 | `--skip-data` | No | Import schema only, skip data |
+| `-w, --work-dir` | No | Working directory for extraction (default: "./db-import-work") |
+| `--trust-server-certificate` | No | Trust server certificate (bypass SSL validation) |
 
 ### export.sh Environment Variables
 | Variable | Description |
@@ -293,7 +299,7 @@ $env:PS_LOG_TIMESTAMP = "true"
 
 ### Export Performance
 - Use `DataRowLimit` for large tables in development environments
-- Exclude unnecessary tables (logs, temp data) with `ExcludeTables`
+- For large or nonessential tables, prefer `SchemaOnlyTables` to export only schema (no data)
 - Run exports during off-peak hours
 - Consider network bandwidth between CI and database server
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ jobs:
           DB_NAME: ${{ secrets.DB_NAME }}
           DB_USERNAME: ${{ secrets.DB_USERNAME }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          # BASH_LOG: info   # uncomment for progress-level logs in CI
+          # BASH_LOG: trace  # uncomment to stream all commands and outputs
         run: ./sqlpack export
 
       - name: Upload Artifact
@@ -231,6 +233,11 @@ BASH_LOG=trace sqlpack import
 # Add timestamps to log messages
 BASH_LOG_TIMESTAMP=true BASH_LOG=debug sqlpack export
 ```
+
+Notes on visibility and CI:
+- `error` (default) keeps console output minimal so failures stand out. Prefer for CI or long unattended runs.
+- `info` shows progress/success lines and can bury errors in long outputs; use interactively with care.
+- `trace` streams all sub-commands and their output for full context; otherwise, detailed tool output is captured to log files and summarized on failure.
 
 **Log Levels (in order of verbosity):**
 - `error` - Only errors (default)
@@ -380,4 +387,4 @@ MIT License - see [LICENSE](LICENSE) file for details.
 - Run from source: `./sqlpack help`
 - Lint Bash scripts: `make lint` (uses shellcheck if available)
 - Run tests: `make test` (runs Bats tests in `tests/` if installed)
-- Increase logging during local runs: `BASH_LOG=debug ./sqlpack import ...` or `PS_LOG_LEVEL=trace pwsh ./commands/export.ps1 ...`
+- Increase logging during local runs: `BASH_LOG=trace ./sqlpack import ...` or `PS_LOG_LEVEL=trace pwsh ./commands/export.ps1 ...`

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -41,4 +41,16 @@ jobs:
 ```
 
 ## GitHub Pages Docs
-Docs are built with MkDocs Material and deployed to `gh-pages`. See workflow in `.github/workflows/docs.yml`.
+Docs are built with MkDocs Material and deployed to the `gh-pages` branch via GitHub Actions. See workflow in `.github/workflows/docs.yml`.
+
+### First-Time Setup (GitHub Pages)
+- Merge the workflow to `main`. The first successful run creates/updates the `gh-pages` branch.
+- In GitHub: Settings → Pages → Build and deployment:
+  - Source: Deploy from a branch
+  - Branch: `gh-pages` and Folder: `/ (root)`
+  - Save. Pages will publish within a minute or two.
+- Your site URL will be `https://<user-or-org>.github.io/<repo>/` (e.g., `https://lionsad.github.io/sqlpack/`).
+
+Optional:
+- Use a custom domain under Settings → Pages → Custom domain.
+- Preview locally with `pip install mkdocs mkdocs-material` then `mkdocs serve`.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,43 @@
+# CI/CD
+
+## GitHub Actions: Export Example
+
+```yaml
+name: Database Export
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PowerShell
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y powershell
+
+      - name: Install dbatools
+        run: pwsh -c "Install-Module dbatools -Force -Scope CurrentUser"
+
+      - name: Export Database
+        env:
+          DB_SERVER: ${{ secrets.DB_SERVER }}
+          DB_NAME: ${{ secrets.DB_NAME }}
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+        run: ./sqlpack export
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: database-dump
+          path: db-dump.tar.gz
+```
+
+## GitHub Pages Docs
+Docs are built with MkDocs Material and deployed to `gh-pages`. See workflow in `.github/workflows/docs.yml`.
+

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -29,6 +29,8 @@ jobs:
           DB_NAME: ${{ secrets.DB_NAME }}
           DB_USERNAME: ${{ secrets.DB_USERNAME }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          # BASH_LOG: info   # uncomment for progress-level logs in CI
+          # BASH_LOG: trace  # uncomment to stream all commands and outputs
         run: ./sqlpack export
 
       - name: Upload Artifact
@@ -40,4 +42,3 @@ jobs:
 
 ## GitHub Pages Docs
 Docs are built with MkDocs Material and deployed to `gh-pages`. See workflow in `.github/workflows/docs.yml`.
-

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -41,3 +41,5 @@ sqlpack doctor --help
 If dbatools is missing, see the Installation guide and dbatools docs at https://docs.dbatools.io/.
 
 Note: `doctor` shows info-level diagnostics by default. You can still override verbosity via `BASH_LOG` (e.g., `debug`, `error`).
+
+Tip: If any tools are missing, run `sqlpack install-tools` to preview or `sqlpack install-tools --execute` to automatically install them (macOS Homebrew or Ubuntu/Debian), then re-run `sqlpack doctor`.

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -5,12 +5,15 @@ Validates your environment for SQLPack export/import workflows.
 ## Usage
 
 ```bash
-# Shows diagnostic output by default
+# Shows info-level diagnostics by default (recommended)
 sqlpack doctor
 
-# Adjust verbosity if needed
+# Increase or decrease verbosity
 BASH_LOG=debug sqlpack doctor
 BASH_LOG=error sqlpack doctor
+
+# Stream every check and command output (trace)
+BASH_LOG=trace sqlpack doctor
 
 # Show help
 sqlpack doctor --help
@@ -40,6 +43,6 @@ sqlpack doctor --help
 
 If dbatools is missing, see the Installation guide and dbatools docs at https://docs.dbatools.io/.
 
-Note: `doctor` shows info-level diagnostics by default. You can still override verbosity via `BASH_LOG` (e.g., `debug`, `error`).
+Note: `doctor` shows info-level diagnostics by default. Override via `BASH_LOG` as needed (use `trace` for deep debugging).
 
 Tip: If any tools are missing, run `sqlpack install-tools` to preview or `sqlpack install-tools --execute` to automatically install them (macOS Homebrew or Ubuntu/Debian), then re-run `sqlpack doctor`.

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -1,0 +1,43 @@
+# Doctor
+
+Validates your environment for SQLPack export/import workflows.
+
+## Usage
+
+```bash
+# Shows diagnostic output by default
+sqlpack doctor
+
+# Adjust verbosity if needed
+BASH_LOG=debug sqlpack doctor
+BASH_LOG=error sqlpack doctor
+
+# Show help
+sqlpack doctor --help
+```
+
+## What It Checks
+- PowerShell (`pwsh`) presence and version
+- dbatools PowerShell module is importable
+- SQL Server tools: `sqlcmd` and `bcp` on PATH
+
+## Exit Codes
+- 0 – All required tools are present
+- 1 – One or more checks failed
+
+## Example Output (success)
+```text
+[INFO]
+[INFO] === SQLPack Doctor ===
+✓ pwsh: found (/usr/local/bin/pwsh)
+✓ dbatools: importable in PowerShell
+✓ sqlcmd: found (/opt/homebrew/bin/sqlcmd)
+✓ bcp: found (/opt/homebrew/bin/bcp)
+[INFO]
+[INFO] === SUMMARY ===
+✓ All required tools are present.
+```
+
+If dbatools is missing, see the Installation guide and dbatools docs at https://docs.dbatools.io/.
+
+Note: `doctor` shows info-level diagnostics by default. You can still override verbosity via `BASH_LOG` (e.g., `debug`, `error`).

--- a/docs/commands/export-data.md
+++ b/docs/commands/export-data.md
@@ -1,0 +1,13 @@
+# Export Data (BCP)
+
+Exports table data using `bcp` in native format with `.fmt` files. Useful for advanced or selective data moves.
+
+## Examples
+
+```bash
+# Export data for listed tables to ./data
+sqlpack export-data -s "localhost,1499" -d MyDb -D ./data -t ./tables.txt
+```
+
+`./tables.txt` should contain `Schema.Table` names, one per line.
+

--- a/docs/commands/export-data.md
+++ b/docs/commands/export-data.md
@@ -6,8 +6,11 @@ Exports table data using `bcp` in native format with `.fmt` files. Useful for ad
 
 ```bash
 # Export data for listed tables to ./data
-sqlpack export-data -s "localhost,1499" -d MyDb -D ./data -t ./tables.txt
+BASH_LOG=info sqlpack export-data -s "localhost,1499" -d MyDb -D ./data -t ./tables.txt
 ```
 
-`./tables.txt` should contain `Schema.Table` names, one per line.
+`./tables.txt` should contain `Database.Schema.Table` names, one per line.
 
+Tip: Use `BASH_LOG=trace` to stream each bcp command and its output.
+
+Note: At `info`/`debug`, command output is captured to `.log` files next to the data/format files and summarized on errors. Use `trace` to stream everything to the console while still writing logs.

--- a/docs/commands/export.md
+++ b/docs/commands/export.md
@@ -16,8 +16,58 @@ DB_ARCHIVE_NAME="myapp-dev-dump.tar.gz" \
 sqlpack export --server localhost,1499 --database MyApp --username sa --password MyPassword
 ```
 
+### Common Scenarios
+
+```bash
+# Use environment variables (recommended for CI)
+export DB_SERVER="prod.server.com,1433"
+export DB_NAME="MyApp"
+export DB_USERNAME="backup_user"
+export DB_PASSWORD="******"
+sqlpack export
+
+# Trusted connection (omit username/password)
+sqlpack export --server "corp-sql01,1433" --database MyApp
+
+# Custom port and archive name
+DB_EXPORT_DIR=./db-export \
+DB_ARCHIVE_NAME=myapp-2024-09-16.tar.gz \
+sqlpack export --server "localhost,1499" --database MyApp
+
+# Limit data volume for dev dumps
+DB_ROW_LIMIT=50000 sqlpack export --server "localhost,1499" --database MyApp
+
+# Exclude heavy tables from data export (schema-only)
+DB_SCHEMA_ONLY_TABLES="AuditLog,LargeFactTable,SessionLog" \
+sqlpack export --server "localhost,1499" --database MyApp
+
+# Trust self-signed certificates when needed
+DB_TRUST_SERVER_CERTIFICATE=true \
+sqlpack export --server "staging.company.net,1433" --database MyApp
+
+# Increase logging for troubleshooting (propagates to PowerShell)
+BASH_LOG=debug sqlpack export --server localhost,1433 --database MyApp
+```
+
+### Verifying Outputs
+
+```bash
+# List generated files
+ls -1 ./db-export
+
+# Inspect table list (Database.Schema.Table)
+sed -n '1,20p' ./db-export/tables.txt
+
+# Show the schema import order
+cat ./db-export/schemas.txt
+
+# Confirm archive exists
+ls -lh ./db-dump.tar.gz
+```
+
 ## Notes
 - Default export directory: `./db-export`
 - Default archive name: `db-dump.tar.gz` in current directory
 - PowerShell exporter uses `dbatools` under the hood (see CI)
 
+Tip: Run `sqlpack doctor` first or use `sqlpack install-tools --execute` to bootstrap sqlcmd/bcp, PowerShell, and dbatools.

--- a/docs/commands/export.md
+++ b/docs/commands/export.md
@@ -74,12 +74,14 @@ Tip: Run `sqlpack doctor` first or use `sqlpack install-tools --execute` to boot
 
 ### Logging
 
-By default, exports only print errors, which can look idle on quiet runs.
+Exports are quiet at the default error level. Choose a level based on your context:
 
 ```bash
-# Recommended during export: show progress and key steps
+# Show progress and key steps during export (interactive runs)
 BASH_LOG=info sqlpack export --server localhost,1433 --database MyApp
 
 # See detailed, real-time schema export and data steps
 BASH_LOG=trace sqlpack export --server localhost,1433 --database MyApp
 ```
+
+Note: `info` prints many success/progress lines and can bury errors in long outputs. For CI/long runs, prefer the default `error` level so failures stand out.

--- a/docs/commands/export.md
+++ b/docs/commands/export.md
@@ -1,0 +1,23 @@
+# Export
+
+Exports database schema and data and produces `./db-export` and `db-dump.tar.gz`.
+
+## Examples
+
+```bash
+# Minimal (server, database)
+sqlpack export --server localhost,1433 --database MyApp
+
+# With credentials and options
+DB_ROW_LIMIT=10000 \
+DB_SCHEMA_ONLY_TABLES="AuditLog,TempData" \
+DB_EXPORT_DIR="./exports" \
+DB_ARCHIVE_NAME="myapp-dev-dump.tar.gz" \
+sqlpack export --server localhost,1499 --database MyApp --username sa --password MyPassword
+```
+
+## Notes
+- Default export directory: `./db-export`
+- Default archive name: `db-dump.tar.gz` in current directory
+- PowerShell exporter uses `dbatools` under the hood (see CI)
+

--- a/docs/commands/export.md
+++ b/docs/commands/export.md
@@ -71,3 +71,15 @@ ls -lh ./db-dump.tar.gz
 - PowerShell exporter uses `dbatools` under the hood (see CI)
 
 Tip: Run `sqlpack doctor` first or use `sqlpack install-tools --execute` to bootstrap sqlcmd/bcp, PowerShell, and dbatools.
+
+### Logging
+
+By default, exports only print errors, which can look idle on quiet runs.
+
+```bash
+# Recommended during export: show progress and key steps
+BASH_LOG=info sqlpack export --server localhost,1433 --database MyApp
+
+# See detailed, real-time schema export and data steps
+BASH_LOG=trace sqlpack export --server localhost,1433 --database MyApp
+```

--- a/docs/commands/import.md
+++ b/docs/commands/import.md
@@ -18,8 +18,44 @@ sqlpack import \
   --force
 ```
 
+### Common Scenarios
+
+```bash
+# Use trusted connection on default port
+sqlpack import --archive db-dump.tar.gz --database MyAppDev --server "corp-sql01,1433"
+
+# Force recreate if DB exists
+sqlpack import --archive db-dump.tar.gz --database MyAppDev --force
+
+# Import schema only (skip data)
+sqlpack import --archive db-dump.tar.gz --database MyAppDev --skip-data
+
+# Trust self-signed certificates
+sqlpack import --archive db-dump.tar.gz --database MyAppDev \
+  --server "staging.company.net,1433" --trust-server-certificate
+
+# Customize the working directory used during extraction
+sqlpack import --archive db-dump.tar.gz --database MyAppDev --work-dir ./tmp/import-work
+
+# Increase logging for troubleshooting
+BASH_LOG=trace sqlpack import --archive db-dump.tar.gz --database MyAppDev
+```
+
+### After Import
+
+```bash
+# Connect with sqlcmd (trusted connection shown)
+sqlcmd -S "localhost,1499" -d MyAppDev -Q "SELECT TOP 5 name FROM sys.tables"
+
+# Connect with SQL auth
+sqlcmd -S "localhost,1499" -U sa -P "YourPassword123" -d MyAppDev -Q "SELECT 1"
+```
+
+Logs are written under `./logs/`. For schema imports, see `./logs/import_<filename>.log`. The sqlcmd wrapper log is `./logs/import-sqlcmd.log`.
+
 ## Notes
 - Working directory: `./db-import-work`
 - Logs written to: `./logs/`
 - Use `--skip-data` to import schema only
 
+Tip: Ensure prerequisites are installed. If not, run `sqlpack install-tools --execute` and verify with `sqlpack doctor`.

--- a/docs/commands/import.md
+++ b/docs/commands/import.md
@@ -41,6 +41,20 @@ sqlpack import --archive db-dump.tar.gz --database MyAppDev --work-dir ./tmp/imp
 BASH_LOG=trace sqlpack import --archive db-dump.tar.gz --database MyAppDev
 ```
 
+### Logging
+
+Imports are quiet at the default error level. Choose a level based on your context:
+
+```bash
+# Show progress and key steps during import
+BASH_LOG=info sqlpack import --archive db-dump.tar.gz --database MyAppDev
+
+# Stream every sqlcmd/bcp invocation and output (verbose troubleshooting)
+BASH_LOG=trace sqlpack import --archive db-dump.tar.gz --database MyAppDev
+```
+
+Note: `info` prints many success/progress lines and can bury errors in long outputs. For CI/long runs, prefer `error`. At `info`/`debug`, detailed tool output is captured to log files and summarized on failure; use `trace` for full console context or inspect the logs in `./logs/` (and per-table logs in the working directory during data import).
+
 ### After Import
 
 ```bash

--- a/docs/commands/import.md
+++ b/docs/commands/import.md
@@ -1,0 +1,25 @@
+# Import
+
+Imports a previously created `db-dump.tar.gz` archive into a target database.
+
+## Examples
+
+```bash
+# Basic import into local dev instance
+sqlpack import --archive db-dump.tar.gz --database MyAppDev
+
+# Custom server/auth and force recreate
+sqlpack import \
+  --archive db-dump.tar.gz \
+  --database MyAppDev \
+  --server "localhost,1499" \
+  --username sa \
+  --password MyPassword \
+  --force
+```
+
+## Notes
+- Working directory: `./db-import-work`
+- Logs written to: `./logs/`
+- Use `--skip-data` to import schema only
+

--- a/docs/commands/install-tools.md
+++ b/docs/commands/install-tools.md
@@ -31,10 +31,9 @@ For other distributions, follow the manual steps in Installation.
 - On macOS, Homebrew commands accept the Microsoft EULA for `msodbcsql18`/`mssql-tools18`.
 - On Ubuntu/Debian, `sudo` is required for `apt` commands.
 - Re-run `sqlpack doctor` after install to verify tools are available on `PATH`.
-- Increase verbosity with `BASH_LOG=debug sqlpack install-tools --execute`.
+- Optional: set `BASH_LOG=trace` to see full command output when troubleshooting.
 
 ## Exit Codes
 - 0 – Success (printed or executed)
 - 1 – Unsupported OS or execution failure
 - 2 – Usage error
-

--- a/docs/commands/install-tools.md
+++ b/docs/commands/install-tools.md
@@ -1,0 +1,40 @@
+# Install Tools
+
+Bootstraps required tools for SQLPack workflows. Detects the OS and prints or executes the appropriate install commands for:
+- mssql-tools18 (`sqlcmd`, `bcp`)
+- PowerShell (`pwsh`)
+- dbatools PowerShell module
+
+## Usage
+
+```bash
+# Preview required commands for your OS
+sqlpack install-tools
+
+# Execute install commands (macOS Homebrew or Ubuntu/Debian apt)
+sqlpack install-tools --execute
+
+# Help
+sqlpack install-tools --help
+```
+
+## Options
+- `--execute` – Run the printed commands in order. Without this flag, the script only prints the commands.
+
+## Supported Systems
+- macOS (Homebrew)
+- Ubuntu/Debian (apt)
+
+For other distributions, follow the manual steps in Installation.
+
+## Notes
+- On macOS, Homebrew commands accept the Microsoft EULA for `msodbcsql18`/`mssql-tools18`.
+- On Ubuntu/Debian, `sudo` is required for `apt` commands.
+- Re-run `sqlpack doctor` after install to verify tools are available on `PATH`.
+- Increase verbosity with `BASH_LOG=debug sqlpack install-tools --execute`.
+
+## Exit Codes
+- 0 – Success (printed or executed)
+- 1 – Unsupported OS or execution failure
+- 2 – Usage error
+

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,13 @@ Environment variables and flags control server, authentication, limits, and outp
 | `DB_ROW_LIMIT` | Max rows per table (export) |
 | `DB_SCHEMA_ONLY_TABLES` | Comma-separated list of tables to export schema only |
 
+### Logging Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `BASH_LOG` | Log level: `error` (default), `warn`, `info` (recommended), `debug`, `trace` |
+| `BASH_LOG_TIMESTAMP` | `true`/`false` to prefix log lines with timestamps |
+
 ## Import Defaults
 - Working directory: `./db-import-work`
 - Logs directory: `./logs/`
@@ -23,4 +30,3 @@ Environment variables and flags control server, authentication, limits, and outp
 - Prefer trusted connections where possible
 - Avoid printing credentials in logs
 - Use `DB_TRUST_SERVER_CERTIFICATE` if needed for development
-

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,26 @@
+# Configuration
+
+Environment variables and flags control server, authentication, limits, and output locations.
+
+## Common Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `DB_SERVER` | SQL Server instance (e.g., `localhost,1499`) |
+| `DB_NAME` | Database name (required for export) |
+| `DB_USERNAME` | SQL Server username (omit for trusted connection) |
+| `DB_PASSWORD` | SQL Server password |
+| `DB_EXPORT_DIR` | Export directory (default: `./db-export`) |
+| `DB_ARCHIVE_NAME` | Archive file name (default: `db-dump.tar.gz`) |
+| `DB_ROW_LIMIT` | Max rows per table (export) |
+| `DB_SCHEMA_ONLY_TABLES` | Comma-separated list of tables to export schema only |
+
+## Import Defaults
+- Working directory: `./db-import-work`
+- Logs directory: `./logs/`
+
+## Security Tips
+- Prefer trusted connections where possible
+- Avoid printing credentials in logs
+- Use `DB_TRUST_SERVER_CERTIFICATE` if needed for development
+

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -17,17 +17,16 @@ make test
 ./sqlpack help
 
 # Export
-./sqlpack export --server localhost,1433 --database MyDb
+BASH_LOG=trace ./sqlpack export --server localhost,1433 --database MyDb
 
 # Import
-./sqlpack import --archive db-dump.tar.gz --database MyDbDev
+BASH_LOG=trace ./sqlpack import --archive db-dump.tar.gz --database MyDbDev
 
 # Export Data (BCP)
-./sqlpack export-data -s "localhost,1499" -d MyDb -D ./data -t ./tables.txt
+BASH_LOG=trace ./sqlpack export-data -s "localhost,1499" -d MyDb -D ./data -t ./tables.txt
 ```
 
 ## Guidelines
 - Bash: `#!/bin/bash` + `set -euo pipefail`, quote vars, prefer arrays
 - PowerShell: explicit parameters, use `[switch]` flags, map to `-Verbose`/`-Debug`
 - Filenames: lowercase kebab-case; functions: lower_snake_case
-

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -1,0 +1,33 @@
+# Development
+
+## Lint and Tests
+
+```bash
+# Lint Bash scripts
+make lint
+
+# Run tests (bats)
+make test
+```
+
+## Useful Commands
+
+```bash
+# Help
+./sqlpack help
+
+# Export
+./sqlpack export --server localhost,1433 --database MyDb
+
+# Import
+./sqlpack import --archive db-dump.tar.gz --database MyDbDev
+
+# Export Data (BCP)
+./sqlpack export-data -s "localhost,1499" -d MyDb -D ./data -t ./tables.txt
+```
+
+## Guidelines
+- Bash: `#!/bin/bash` + `set -euo pipefail`, quote vars, prefer arrays
+- PowerShell: explicit parameters, use `[switch]` flags, map to `-Verbose`/`-Debug`
+- Filenames: lowercase kebab-case; functions: lower_snake_case
+

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,9 @@
 # FAQ
 
+## It looks like nothing is happening
+- Default logging is quiet (`BASH_LOG=error`). Run with `BASH_LOG=info` to see progress, or `BASH_LOG=trace` to stream all commands and outputs.
+- For imports, check logs in `./logs/`.
+
 ## Common Export Issues
 - dbatools not found: `Install-Module dbatools -Scope CurrentUser -Force`
 - `bcp` not found: install SQL Server command line tools and ensure PATH
@@ -12,4 +16,3 @@
 
 ## Where are logs?
 - Import logs under `./logs/` with per-file details
-

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,15 @@
+# FAQ
+
+## Common Export Issues
+- dbatools not found: `Install-Module dbatools -Scope CurrentUser -Force`
+- `bcp` not found: install SQL Server command line tools and ensure PATH
+- Connection timeouts: verify firewall, remote connections, test with `sqlcmd`
+
+## Common Import Issues
+- Database exists: use `--force` to recreate
+- Permission denied: ensure user has CREATE DATABASE rights
+- Data mismatches: check schema alignment and constraints
+
+## Where are logs?
+- Import logs under `./logs/` with per-file details
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,26 +4,38 @@ A cross-platform toolkit to export SQL Server databases and import them into dev
 
 ## Quick Start
 
+Prerequisites (tools): see Installation for setup. You need `sqlcmd` and `bcp` (mssql-tools18), PowerShell 7+ (`pwsh`), and the dbatools module.
+
 ```bash
-# Install to /usr/local (requires sudo)
+# 1) Install SQLPack (to /usr/local; use PREFIX for custom path)
 sudo make install
 
-# Export a database (creates ./db-export and db-dump.tar.gz)
+# 2) Install required tools (preview or execute)
+# Preview the commands for your OS
+sqlpack install-tools
+# Execute them automatically (macOS Homebrew or Ubuntu/Debian apt)
+sqlpack install-tools --execute
+
+# 3) Validate your environment (PowerShell, dbatools, sqlcmd, bcp)
+sqlpack doctor
+
+# 4) Export a database (creates ./db-export and db-dump.tar.gz)
 sqlpack export --server localhost,1433 --database MyApp
 
-# Import into a local dev instance
+# 5) Import into a local dev instance
 sqlpack import --archive db-dump.tar.gz --database MyAppDev
 
-# Help
+# 6) Explore help for flags and env vars
 sqlpack help
 sqlpack export --help
+sqlpack import --help
 ```
 
-- Run `sqlpack doctor` to validate your environment.
-- Prerequisites: `sqlcmd` (mssql-tools18), PowerShell, and the dbatools module. See [Installation](install.md) for setup.
-- See Installation for system and dev setup.
-- See Usage for an overview and common flows.
-- See Commands for detailed options per subcommand.
+- `sqlpack install-tools` previews or executes tool installation steps.
+- Use `sqlpack doctor` before first use or when troubleshooting.
+- See [Installation](install.md) to set up tools and environment.
+- See [Usage](usage.md) for common flows and quick examples.
+- See [Commands] for detailed flags: [Export](commands/export.md), [Import](commands/import.md), [Export Data](commands/export-data.md), [Doctor](commands/doctor.md).
 
 ## What You Get
 - Repeatable exports for CI with schema + data

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ sqlpack help
 sqlpack export --help
 ```
 
+- Run `sqlpack doctor` to validate your environment.
 - Prerequisites: `sqlcmd` (mssql-tools18), PowerShell, and the dbatools module. See [Installation](install.md) for setup.
 - See Installation for system and dev setup.
 - See Usage for an overview and common flows.

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ sqlpack import --help
 - Use `sqlpack doctor` before first use or when troubleshooting.
 - See [Installation](install.md) to set up tools and environment.
 - See [Usage](usage.md) for common flows and quick examples.
-- See [Commands] for detailed flags: [Export](commands/export.md), [Import](commands/import.md), [Export Data](commands/export-data.md), [Doctor](commands/doctor.md).
+- See [Commands] for detailed flags: [Install Tools](commands/install-tools.md), [Export](commands/export.md), [Import](commands/import.md), [Export Data](commands/export-data.md), [Doctor](commands/doctor.md).
 
 ## What You Get
 - Repeatable exports for CI with schema + data

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ sqlpack import --help
 - Use `sqlpack doctor` before first use or when troubleshooting.
 - See [Installation](install.md) to set up tools and environment.
 - See [Usage](usage.md) for common flows and quick examples.
-- See [Commands] for detailed flags: [Install Tools](commands/install-tools.md), [Export](commands/export.md), [Import](commands/import.md), [Export Data](commands/export-data.md), [Doctor](commands/doctor.md).
+- See [Commands] for detailed flags: [Export](commands/export.md), [Import](commands/import.md), [Export Data](commands/export-data.md), [Doctor](commands/doctor.md), [Install Tools](commands/install-tools.md).
 
 ## What You Get
 - Repeatable exports for CI with schema + data

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,34 @@
+# SQLPack
+
+A cross-platform toolkit to export SQL Server databases and import them into developer environments. SQLPack unifies Bash and PowerShell helpers behind a single `sqlpack` CLI for consistent usage on macOS, Linux, and Windows.
+
+## Quick Start
+
+```bash
+# Install to /usr/local (requires sudo)
+sudo make install
+
+# Export a database (creates ./db-export and db-dump.tar.gz)
+sqlpack export --server localhost,1433 --database MyApp
+
+# Import into a local dev instance
+sqlpack import --archive db-dump.tar.gz --database MyAppDev
+
+# Help
+sqlpack help
+sqlpack export --help
+```
+
+- See Installation for system and dev setup.
+- See Usage for an overview and common flows.
+- See Commands for detailed options per subcommand.
+
+## What You Get
+- Repeatable exports for CI with schema + data
+- Developer-friendly imports with logs in `./logs/`
+- Cross-platform scripts with consistent logging and flags
+
+## Links
+- Repository: https://github.com/LionsAd/sqlpack
+- Issues: https://github.com/LionsAd/sqlpack/issues
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,10 @@ A cross-platform toolkit to export SQL Server databases and import them into dev
 
 Prerequisites (tools): see Installation for setup. You need `sqlcmd` and `bcp` (mssql-tools18), PowerShell 7+ (`pwsh`), and the dbatools module.
 
+Tip on verbosity: commands are quiet at the default `BASH_LOG=error`. For day‑to‑day runs, `BASH_LOG=info` shows progress; use `BASH_LOG=trace` to see everything (full tool output). At `info`/`debug`, detailed tool output may be summarized; open the referenced logs or use `trace` for full console visibility.
+
+Caution: `info` adds many success/progress lines and can make errors easier to overlook in long runs. The default `error` level is intentional to keep failures obvious; prefer it for CI or longer unattended runs.
+
 ```bash
 # 1) Install SQLPack (to /usr/local; use PREFIX for custom path)
 sudo make install
@@ -20,10 +24,10 @@ sqlpack install-tools --execute
 sqlpack doctor
 
 # 4) Export a database (creates ./db-export and db-dump.tar.gz)
-sqlpack export --server localhost,1433 --database MyApp
+BASH_LOG=info sqlpack export --server localhost,1433 --database MyApp
 
 # 5) Import into a local dev instance
-sqlpack import --archive db-dump.tar.gz --database MyAppDev
+BASH_LOG=info sqlpack import --archive db-dump.tar.gz --database MyAppDev
 
 # 6) Explore help for flags and env vars
 sqlpack help
@@ -35,7 +39,8 @@ sqlpack import --help
 - Use `sqlpack doctor` before first use or when troubleshooting.
 - See [Installation](install.md) to set up tools and environment.
 - See [Usage](usage.md) for common flows and quick examples.
-- See [Commands] for detailed flags: [Export](commands/export.md), [Import](commands/import.md), [Export Data](commands/export-data.md), [Doctor](commands/doctor.md), [Install Tools](commands/install-tools.md).
+- See [Logging](logging.md) for recommended verbosity and tips.
+- Commands reference: [Export](commands/export.md), [Import](commands/import.md), [Export Data](commands/export-data.md), [Doctor](commands/doctor.md), [Install Tools](commands/install-tools.md).
 
 ## What You Get
 - Repeatable exports for CI with schema + data

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ sqlpack help
 sqlpack export --help
 ```
 
+- Prerequisites: `sqlcmd` (mssql-tools18), PowerShell, and the dbatools module. See [Installation](install.md) for setup.
 - See Installation for system and dev setup.
 - See Usage for an overview and common flows.
 - See Commands for detailed options per subcommand.
@@ -31,4 +32,3 @@ sqlpack export --help
 ## Links
 - Repository: https://github.com/LionsAd/sqlpack
 - Issues: https://github.com/LionsAd/sqlpack/issues
-

--- a/docs/install.md
+++ b/docs/install.md
@@ -57,7 +57,9 @@ sqlcmd -?
 bcp -?
 ```
 
-If you run into issues or use a different OS, see Microsoft’s official docs for installing SQL Server tools.
+Microsoft docs:
+- Install SQL Server command-line tools on macOS: https://learn.microsoft.com/sql/linux/sql-server-linux-setup-tools?view=sql-server-ver17#macos
+- ODBC Driver 18 for SQL Server: https://learn.microsoft.com/sql/connect/odbc/download-odbc-driver-for-sql-server
 
 ### Ubuntu/Debian (summary)
 
@@ -70,6 +72,9 @@ echo 'export PATH="/opt/mssql-tools18/bin:$PATH"' >> ~/.bashrc
 source ~/.bashrc
 sqlcmd -?
 ```
+
+Microsoft docs:
+- Linux tools install (Ubuntu/Debian/RHEL/Fedora): https://learn.microsoft.com/sql/linux/sql-server-linux-setup-tools?view=sql-server-ver17
 
 ## Install PowerShell and dbatools
 
@@ -89,9 +94,18 @@ pwsh -NoLogo -NoProfile -Command "Install-Module dbatools -Scope CurrentUser -Fo
 pwsh -NoLogo -NoProfile -Command "Import-Module dbatools; Get-Module dbatools"
 ```
 
+Microsoft docs:
+- Install PowerShell on macOS: https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-macos?view=powershell-7.4
+
 ### Ubuntu/Debian (summary)
 
 ```bash
 sudo apt-get update && sudo apt-get install -y powershell
 pwsh -NoLogo -NoProfile -Command "Install-Module dbatools -Scope CurrentUser -Force"
 ```
+
+Microsoft docs:
+- Install PowerShell on Linux: https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-linux?view=powershell-7.4
+
+dbatools docs:
+- Install dbatools: https://dbatools.io/install/

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,5 +1,7 @@
 # Installation
 
+> Quick bootstrap: `sqlpack install-tools` prints the required commands for your OS; add `--execute` to run them automatically (macOS Homebrew or Ubuntu/Debian apt). After installation, verify with `sqlpack doctor`.
+
 ## System-wide Install
 
 ```bash

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,34 @@
+# Installation
+
+## System-wide Install
+
+```bash
+# Install to /usr/local (requires sudo)
+sudo make install
+
+# Or install to a custom prefix (no sudo)
+PREFIX=$HOME/.local make install
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+## Development Usage
+
+```bash
+# Run directly from source
+./sqlpack help
+```
+
+## Uninstall
+
+```bash
+sudo make uninstall
+
+# Or for custom prefix
+PREFIX=$HOME/.local make uninstall
+```
+
+## Prerequisites
+- PowerShell Core for export in CI (dbatools module)
+- SQL Server client tools (`sqlcmd`, `bcp` as needed)
+- tar utility (usually available on macOS/Linux)
+

--- a/docs/install.md
+++ b/docs/install.md
@@ -58,8 +58,8 @@ bcp -?
 ```
 
 Microsoft docs:
-- Install SQL Server command-line tools on macOS: https://learn.microsoft.com/sql/linux/sql-server-linux-setup-tools?view=sql-server-ver17#macos
-- ODBC Driver 18 for SQL Server: https://learn.microsoft.com/sql/connect/odbc/download-odbc-driver-for-sql-server
+- [Install SQL Server command-line tools on macOS](https://learn.microsoft.com/sql/linux/sql-server-linux-setup-tools?view=sql-server-ver17#macos)
+- [ODBC Driver 18 for SQL Server](https://learn.microsoft.com/sql/connect/odbc/download-odbc-driver-for-sql-server)
 
 ### Ubuntu/Debian (summary)
 
@@ -74,7 +74,7 @@ sqlcmd -?
 ```
 
 Microsoft docs:
-- Linux tools install (Ubuntu/Debian/RHEL/Fedora): https://learn.microsoft.com/sql/linux/sql-server-linux-setup-tools?view=sql-server-ver17
+- [Linux tools install (Ubuntu/Debian/RHEL/Fedora)](https://learn.microsoft.com/sql/linux/sql-server-linux-setup-tools?view=sql-server-ver17)
 
 ## Install PowerShell and dbatools
 
@@ -95,7 +95,7 @@ pwsh -NoLogo -NoProfile -Command "Import-Module dbatools; Get-Module dbatools"
 ```
 
 Microsoft docs:
-- Install PowerShell on macOS: https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-macos?view=powershell-7.4
+- [Install PowerShell on macOS](https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-macos?view=powershell-7.4)
 
 ### Ubuntu/Debian (summary)
 
@@ -105,7 +105,7 @@ pwsh -NoLogo -NoProfile -Command "Install-Module dbatools -Scope CurrentUser -Fo
 ```
 
 Microsoft docs:
-- Install PowerShell on Linux: https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-linux?view=powershell-7.4
+- [Install PowerShell on Linux](https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-linux?view=powershell-7.4)
 
 dbatools docs:
-- Install dbatools: https://dbatools.io/install/
+- [Install dbatools](https://dbatools.io/install/)

--- a/docs/install.md
+++ b/docs/install.md
@@ -32,3 +32,66 @@ PREFIX=$HOME/.local make uninstall
 - SQL Server client tools (`sqlcmd`, `bcp` as needed)
 - tar utility (usually available on macOS/Linux)
 
+## Install sqlcmd and bcp (mssql-tools18)
+
+### macOS (Homebrew)
+
+```bash
+# Tap Microsoft's Homebrew repo
+brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
+
+# Accept EULA and install ODBC + tools
+ACCEPT_EULA=Y brew install msodbcsql18 mssql-tools18
+
+# Add mssql-tools18 to PATH (Apple Silicon)
+echo 'export PATH="/opt/homebrew/opt/mssql-tools18/bin:$PATH"' >> ~/.zshrc
+
+# For Intel Macs use:
+# echo 'export PATH="/usr/local/opt/mssql-tools18/bin:$PATH"' >> ~/.zshrc
+
+# Reload shell config (or open a new terminal)
+source ~/.zshrc
+
+# Verify
+sqlcmd -?
+bcp -?
+```
+
+If you run into issues or use a different OS, see Microsoft’s official docs for installing SQL Server tools.
+
+### Ubuntu/Debian (summary)
+
+Follow Microsoft’s instructions to add the package repo, then install:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y msodbcsql18 mssql-tools18
+echo 'export PATH="/opt/mssql-tools18/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+sqlcmd -?
+```
+
+## Install PowerShell and dbatools
+
+### macOS
+
+```bash
+# Install PowerShell
+brew install --cask powershell
+
+# Verify
+pwsh -v
+
+# Install dbatools module (current user scope)
+pwsh -NoLogo -NoProfile -Command "Install-Module dbatools -Scope CurrentUser -Force"
+
+# Verify module loads
+pwsh -NoLogo -NoProfile -Command "Import-Module dbatools; Get-Module dbatools"
+```
+
+### Ubuntu/Debian (summary)
+
+```bash
+sudo apt-get update && sudo apt-get install -y powershell
+pwsh -NoLogo -NoProfile -Command "Install-Module dbatools -Scope CurrentUser -Force"
+```

--- a/docs/install.md
+++ b/docs/install.md
@@ -108,4 +108,4 @@ Microsoft docs:
 - [Install PowerShell on Linux](https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-linux?view=powershell-7.4)
 
 dbatools docs:
-- [Install dbatools](https://dbatools.io/install/)
+- [dbatools documentation](https://docs.dbatools.io/)

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -2,18 +2,28 @@
 
 SQLPack scripts support configurable logging for both Bash and PowerShell wrappers.
 
+Recommended defaults:
+- Default is `error` to keep failures highly visible (minimal noise).
+- Use `info` during interactive runs to see progress, but be aware it can drown out errors in long runs.
+- Use `trace` to stream every command and full output for troubleshooting.
+
+Note on error visibility:
+- Full tool output is not printed at `error`/`info`/`debug` levels; commands write detailed logs to files and show summaries on failure.
+- `error` keeps console output concise so failures stand out (fewer success lines to bury errors).
+- `info` adds many success/progress lines, which can make errors easier to miss in long runs. Prefer `error` for CI/long runs; switch to `trace` when you need full, live context.
+
 ## Bash Scripts
 
 Use `BASH_LOG` to control verbosity and `BASH_LOG_TIMESTAMP=true` to add timestamps.
 
 ```bash
-# Default: errors only
+# Default: errors only (quiet)
 sqlpack export
 
 # Info level
 BASH_LOG=info sqlpack export
 
-# Debug/trace
+# Debug and trace
 BASH_LOG=debug sqlpack export-data
 BASH_LOG=trace sqlpack import
 
@@ -37,5 +47,6 @@ pwsh ./commands/export.ps1 -SqlInstance "server" -Database "db" -Debug
 # Environment variable
 $env:PS_LOG_LEVEL = "Debug"
 pwsh ./commands/export.ps1 -SqlInstance "server" -Database "db"
-```
 
+Tip: `sqlpack export`/`commands/export.sh` propagate `BASH_LOG` to PowerShell via `PS_LOG_LEVEL` automatically when set.
+```

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,41 @@
+# Logging
+
+SQLPack scripts support configurable logging for both Bash and PowerShell wrappers.
+
+## Bash Scripts
+
+Use `BASH_LOG` to control verbosity and `BASH_LOG_TIMESTAMP=true` to add timestamps.
+
+```bash
+# Default: errors only
+sqlpack export
+
+# Info level
+BASH_LOG=info sqlpack export
+
+# Debug/trace
+BASH_LOG=debug sqlpack export-data
+BASH_LOG=trace sqlpack import
+
+# Add timestamps
+BASH_LOG_TIMESTAMP=true BASH_LOG=debug sqlpack export
+```
+
+Log files for import are written to `./logs/`.
+
+## PowerShell (export.ps1)
+
+Use `-Verbose`, `-Debug`, or `PS_LOG_LEVEL`.
+
+```powershell
+# Verbose
+pwsh ./commands/export.ps1 -SqlInstance "server" -Database "db" -Verbose
+
+# Debug
+pwsh ./commands/export.ps1 -SqlInstance "server" -Database "db" -Debug
+
+# Environment variable
+$env:PS_LOG_LEVEL = "Debug"
+pwsh ./commands/export.ps1 -SqlInstance "server" -Database "db"
+```
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,6 +5,9 @@ SQLPack provides a unified CLI via `sqlpack` with subcommands for export, import
 ## Quick Examples
 
 ```bash
+# Bootstrap tools (macOS Homebrew or Ubuntu/Debian apt)
+sqlpack install-tools --execute
+
 # Export (creates ./db-export and db-dump.tar.gz)
 sqlpack export --server localhost,1433 --database MyApp
 
@@ -16,4 +19,3 @@ sqlpack export-data -s "localhost,1499" -d MyDb -D ./data -t ./tables.txt
 ```
 
 See the individual command pages for flags and environment variables.
-

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,13 +9,16 @@ SQLPack provides a unified CLI via `sqlpack` with subcommands for export, import
 sqlpack install-tools --execute
 
 # Export (creates ./db-export and db-dump.tar.gz)
-sqlpack export --server localhost,1433 --database MyApp
+BASH_LOG=info sqlpack export --server localhost,1433 --database MyApp
 
 # Import into local dev
-sqlpack import --archive db-dump.tar.gz --database MyAppDev
+BASH_LOG=info sqlpack import --archive db-dump.tar.gz --database MyAppDev
 
 # Export data with BCP helper
-sqlpack export-data -s "localhost,1499" -d MyDb -D ./data -t ./tables.txt
+BASH_LOG=info sqlpack export-data -s "localhost,1499" -d MyDb -D ./data -t ./tables.txt
 ```
 
 See the individual command pages for flags and environment variables.
+
+Tip: Use `BASH_LOG=trace` to stream all sub-commands and outputs when debugging.
+Note: `info` adds progress lines and can bury errors in long outputs; prefer default `error` for CI/long runs. At `info`/`debug`, some tool output is summarized; check the generated logs or switch to `trace` for full console visibility.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,19 @@
+# Usage Overview
+
+SQLPack provides a unified CLI via `sqlpack` with subcommands for export, import, and data export.
+
+## Quick Examples
+
+```bash
+# Export (creates ./db-export and db-dump.tar.gz)
+sqlpack export --server localhost,1433 --database MyApp
+
+# Import into local dev
+sqlpack import --archive db-dump.tar.gz --database MyAppDev
+
+# Export data with BCP helper
+sqlpack export-data -s "localhost,1499" -d MyDb -D ./data -t ./tables.txt
+```
+
+See the individual command pages for flags and environment variables.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,9 +34,9 @@ nav:
     - Export: commands/export.md
     - Import: commands/import.md
     - Export Data (BCP): commands/export-data.md
+    - Doctor: commands/doctor.md
   - Configuration: configuration.md
   - Logging: logging.md
   - CI/CD: ci.md
   - Development: develop.md
   - FAQ: faq.md
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,11 +31,11 @@ nav:
   - Installation: install.md
   - Usage: usage.md
   - Commands:
-    - Install Tools: commands/install-tools.md
     - Export: commands/export.md
     - Import: commands/import.md
     - Export Data (BCP): commands/export-data.md
     - Doctor: commands/doctor.md
+    - Install Tools: commands/install-tools.md
   - Configuration: configuration.md
   - Logging: logging.md
   - CI/CD: ci.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
   - Installation: install.md
   - Usage: usage.md
   - Commands:
+    - Install Tools: commands/install-tools.md
     - Export: commands/export.md
     - Import: commands/import.md
     - Export Data (BCP): commands/export-data.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,42 @@
+site_name: SQLPack
+site_description: Cross-platform database export/import utility for SQL Server
+site_url: https://lionsad.github.io/sqlpack/
+repo_name: LionsAd/sqlpack
+repo_url: https://github.com/LionsAd/sqlpack
+edit_uri: blob/main/
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.top
+    - content.code.copy
+  palette:
+    - scheme: default
+
+markdown_extensions:
+  - admonition
+  - codehilite
+  - toc:
+      permalink: true
+  - tables
+  - pymdownx.details
+  - pymdownx.superfences
+
+plugins:
+  - search
+
+nav:
+  - Home: index.md
+  - Installation: install.md
+  - Usage: usage.md
+  - Commands:
+    - Export: commands/export.md
+    - Import: commands/import.md
+    - Export Data (BCP): commands/export-data.md
+  - Configuration: configuration.md
+  - Logging: logging.md
+  - CI/CD: ci.md
+  - Development: develop.md
+  - FAQ: faq.md
+


### PR DESCRIPTION
Summary
- Launch public docs with MkDocs Material and a GitHub Actions workflow that deploys to gh-pages.
- Align logging guidance across docs: default error (failures stand out), info for interactive progress (can bury errors), trace for full, live output.
- Improve consistency and clarity across Quick Start, Usage, Commands, CI, and README.

First-Time GitHub Pages Setup
- Merge this PR to main. The workflow will build and publish the site to gh-pages.
- In GitHub: Settings → Pages → Build and deployment:
  - Source: Deploy from a branch
  - Branch: gh-pages, Folder: /(root)
- Docs URL format: https://<user-or-org>.github.io/<repo>/ (e.g., https://lionsad.github.io/sqlpack/)
- Optional: set a custom domain. Local preview: pip install mkdocs mkdocs-material && mkdocs serve

Key Changes
- index.md: logging tip with caution about info; link to Logging; command refs tightened.
- logging.md: rationale for default error; info caveat; trace behavior; log capture/summaries.
- usage.md: examples updated; trace tip; info caveat for long runs.
- commands/export.md, import.md: per-command logging guidance; caution that info can bury errors; recommend error for CI/long runs.
- commands/export-data.md: correct tables file format (Database.Schema.Table); add trace note; mention log files.
- commands/doctor.md: defaults clarified (no need for info/help); examples for debug/error/trace.
- commands/install-tools.md: remove BASH_LOG=info from examples; optional trace note.
- ci.md: remove BASH_LOG from default env; add commented info/trace options for opt-in verbosity; add first-time setup section.
- configuration.md: document BASH_LOG and BASH_LOG_TIMESTAMP.
- install.md, develop.md: recommend trace for local dev; small clarifications.
- README.md: new Documentation section (Pages link, local preview, first-time setup); CI example shows commented BASH_LOG options; logging notes updated; recommend trace for local dev.

CI/Docs
- Workflow: .github/workflows/docs.yml builds with `mkdocs build --strict` and deploys to gh-pages.
- After merge: enable GitHub Pages with gh-pages/(root), as above.

Verification
- mkdocs build --strict passes locally.
- Documentation-only changes; no breaking changes.

Notes
- Default error remains intentional to keep failures obvious (especially in CI).
- info is useful interactively but can drown error signals in long outputs.
- trace provides full, live diagnostics and still writes logs.