### PR TITLE
Update argument for homebrew

### DIFF
--- a/commands/install-tools.sh
+++ b/commands/install-tools.sh
@@ -84,7 +84,7 @@ build_commands() {
         macos)
             if [[ $HAVE_MSSQL_TOOLS -eq 0 ]]; then
                 cmds+=("brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release")
-                cmds+=("ACCEPT_EULA=Y brew install msodbcsql18 mssql-tools18")
+                cmds+=("HOMEBREW_ACCEPT_EULA=Y brew install msodbcsql18 mssql-tools18")
             fi
             if [[ $HAVE_PWSH -eq 0 ]]; then
                 cmds+=("brew install --cask powershell")


### PR DESCRIPTION
When running `sqlpack install-tools --execute` on macos, I got stuck at the "accept license terms"

```
==> Installing msodbcsql18 from microsoft/mssql-release
brew install --cask powershell
pwsh -NoLogo -NoProfile -Command "Install-Module dbatools -Scope CurrentUser -Force"
The license terms for this product can be downloaded from
https://aka.ms/odbc18eula and found in
/opt/homebrew/Cellar/msodbcsql18/18.5.1.1/share/doc/msodbcsql18/LICENSE.txt . By entering 'YES',
you indicate that you accept the license terms.

Do you accept the license terms? (Enter YES or NO)
Please enter YES or NO
Do you accept the license terms? (Enter YES or NO)
Please enter YES or NO
Do you accept the license terms? (Enter YES or NO)
```

Typing Y, yes, YES etc did not work and the install would hang here indefinitely.

It seems like the `ACCEPT_EULA=Y` is for Linux and didn't work in homebrew.

https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/install-microsoft-odbc-driver-sql-server-macos?view=sql-server-ver17#microsoft-odbc-18

This PR changes the flag to `HOMEBREW_ACCEPT_EULA=Y` which was allowed me to bypass this prompt and finish the installation.