### PR TITLE
Set options.ScriptBatchTerminator to true when exporting Views

### DIFF
--- a/commands/export.ps1
+++ b/commands/export.ps1
@@ -415,7 +415,7 @@ function Export-DatabaseSchema {
             $options = New-DbaScriptingOption
             $options.ScriptSchema = $true
             $options.IncludeHeaders = $true
-            $options.ScriptBatchTerminator = $false
+            $options.ScriptBatchTerminator = $true
             $options.AnsiFile = $true
             return $options
         })


### PR DESCRIPTION
This adds `GO` before calls to `CREATE VIEW` to avoid this error.

```
Error summary:
         'CREATE VIEW' must be the first statement in a query batch.
         Msg 111, Level 15, State 1, Server ddev-aftconnect10-sqlsrv, Line 384
         'CREATE VIEW' must be the first statement in a query batch.
         Full details in: logs/import_schema-views.log
```