### PR TITLE
Fix remaining ((FAILED_COUNT++)) arithmetic syntax

### DIFF
--- a/commands/import.sh
+++ b/commands/import.sh
@@ -458,7 +458,7 @@ if [[ "$SKIP_DATA" == false ]]; then
             fi
         else
             print_warning "Invalid table format: $TABLE_FULL"
-            ((FAILED_COUNT++))
+            FAILED_COUNT=$((FAILED_COUNT + 1))
         fi
     done < "$TABLES_FILE"
 


### PR DESCRIPTION
## Summary

Fix the remaining `((FAILED_COUNT++))` arithmetic syntax that was missed in PR #11.

## Changes

- Changed `((FAILED_COUNT++))` to `FAILED_COUNT=$((FAILED_COUNT + 1))` on line 461

## Why

The `((var++))` syntax fails under `set -e` when incrementing from 0, because the expression evaluates to 0 (falsy), triggering errexit. This causes unexpected script termination.

While this code path (triggered by "Invalid table format" errors) is less common than the paths fixed in PR #11, it would still cause early exit if encountered as the first failure.

Fixes #12

🤖 Generated with [Claude Code](https://claude.ai/code)
